### PR TITLE
Enable unit tests when targeting wasm32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,17 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(CTest)
+message(STATUS "${CMAKE_CURRENT_LIST_FILE}: BUILD_TESTING=${BUILD_TESTING}")
+if(BUILD_TESTING)
+  enable_testing()
+
+  # Enable official support for tests with whitespace and other special
+  # characters in the name specified to add_test().
+  # https://cmake.org/cmake/help/v3.19/policy/CMP0110.html
+  cmake_policy(SET CMP0110 NEW)
+endif()
+
 if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm32")
   set(WASMDEMO_TARGET_WASM32 YES)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Set WASMDEMO_TARGET_WASM32 to YES if the build is targeting WebAssembly or
-# NO if targeting any other platform (e.g. desktop).
 if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "wasm32")
   set(WASMDEMO_TARGET_WASM32 YES)
-elseif(WASMDEMO_CLANG_TARGET STREQUAL "native")
+else()
   set(WASMDEMO_TARGET_WASM32 NO)
 endif()
 
@@ -36,7 +34,6 @@ set(WASMDEMO_WARNING_FLAGS
 
 add_compile_options(${WASMDEMO_WARNING_FLAGS})
 if(WASMDEMO_TARGET_WASM32)
-  add_compile_options(-fvisibility=hidden)
   add_compile_options($<$<CONFIG:Release>:-ffunction-sections>)
   add_compile_options($<$<CONFIG:Release>:-fdata-sections>)
   add_compile_options($<$<CONFIG:Release>:-flto>)
@@ -44,7 +41,6 @@ endif()
 
 add_link_options(${WASMDEMO_WARNING_FLAGS})
 if(WASMDEMO_TARGET_WASM32)
-  add_link_options(-fvisibility=hidden)
   add_link_options($<$<CONFIG:Release>:-ffunction-sections>)
   add_link_options($<$<CONFIG:Release>:-fdata-sections>)
   add_link_options($<$<CONFIG:Release>:-flto>)
@@ -53,10 +49,15 @@ if(WASMDEMO_TARGET_WASM32)
   add_link_options($<$<CONFIG:Release>:-Wl,--gc-sections>)
 endif()
 
+if(WASMDEMO_TARGET_WASM32)
+  add_compile_definitions(GTEST_HAS_EXCEPTIONS=0)
+  add_compile_definitions(GTEST_HAS_STREAM_REDIRECTION=0)
+  set(gtest_disable_pthreads YES CACHE BOOL "Disable pthreads in googletest" FORCE)
+endif()
+
 add_subdirectory(cpp)
+add_subdirectory(external)
 
 if(WASMDEMO_TARGET_WASM32)
   add_subdirectory(www)
-else()
-  add_subdirectory(external)
 endif()

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ The following software must be installed in order to build the project:
 * ninja build tool.
 * clang and llvm with wasm32 support
 * wasi-sdk sysroot
+* wasmtime
 
-Cmake and Ninja can be installed in many ways. On macOS and Linux, I just use
-homebrew (i.e. `brew install cmake ninja`). It can also be installed using
-Python's package manager (i.e. `pip install cmake ninja`).
+cmake, ninja, and wasmtime can be installed in many ways. On macOS and Linux, I
+just use homebrew (i.e. `brew install cmake ninja wasmtime`). cmake and ninja
+can also be installed using Python's package manager
+(i.e. `pip install cmake ninja`).
 
 Operating Systems like macOS and Ubuntu often don't ship with a clang that
 includes wasm32 support. So you set up a clang that _does_ have wasm32 support.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,62 +1,74 @@
-set(
-  wasmdemo_srcs
+add_library(
+  wasmdemo_lib
+  OBJECT
   src/wasmdemo.cc
   src/hash.cc
   src/bloom.cc
 )
 
-if(WASMDEMO_TARGET_WASM32)
-  add_executable(wasmdemo ${wasmdemo_srcs})
-  set_property(TARGET wasmdemo PROPERTY OUTPUT_NAME wasmdemo.wasm)
-
-  target_include_directories(
-    wasmdemo
-    PRIVATE
-    "${CMAKE_CURRENT_LIST_DIR}/include/wasm32"
-  )
-else()
-  add_library(wasmdemo ${wasmdemo_srcs})
-
-  target_include_directories(
-    wasmdemo
-    PUBLIC
-    "${CMAKE_CURRENT_LIST_DIR}/include/nonwasm32"
-  )
-
-  add_executable(
-    wasmdemo_test
-    test/wasmdemo_imports_impl.cc
-    test/wasmdemo_test.cc
-  )
-
-  target_include_directories(
-    wasmdemo_test
-    PUBLIC
-    "${CMAKE_CURRENT_LIST_DIR}/test"
-  )
-
-  target_link_libraries(
-    wasmdemo_test
-    PRIVATE
-    wasmdemo
-    gmock_main
-  )
-endif()
-
-target_include_directories(
-  wasmdemo
-  PUBLIC
-  "${CMAKE_CURRENT_LIST_DIR}/include/common"
-)
-
 target_compile_options(
-  wasmdemo
+  wasmdemo_lib
   PRIVATE
   -Werror
 )
 
 target_link_options(
-  wasmdemo
+  wasmdemo_lib
   PRIVATE
   -Werror
+)
+
+target_include_directories(
+  wasmdemo_lib
+  PUBLIC
+  "${CMAKE_CURRENT_LIST_DIR}/include/common"
+)
+
+if(WASMDEMO_TARGET_WASM32)
+  target_include_directories(
+    wasmdemo_lib
+    PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include/wasm32"
+  )
+else()
+  target_include_directories(
+    wasmdemo_lib
+    PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include/nonwasm32"
+  )
+endif()
+
+if(WASMDEMO_TARGET_WASM32)
+  add_executable(wasmdemo src/wasmdemo_main.cc)
+  set_property(TARGET wasmdemo PROPERTY OUTPUT_NAME wasmdemo.wasm)
+  target_link_libraries(
+    wasmdemo
+    PUBLIC
+    wasmdemo_lib
+  )
+  target_link_options(
+    wasmdemo
+    PUBLIC
+    "-nostartfiles"
+    "-Wl,--no-entry"
+  )
+endif()
+
+add_executable(
+  wasmdemo_test
+  test/wasmdemo_imports_impl.cc
+  test/wasmdemo_test.cc
+)
+
+target_include_directories(
+  wasmdemo_test
+  PUBLIC
+  "${CMAKE_CURRENT_LIST_DIR}/test"
+)
+
+target_link_libraries(
+  wasmdemo_test
+  PRIVATE
+  wasmdemo_lib
+  gmock_main
 )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,3 +1,7 @@
+###############################################################################
+# wasmdemo_lib
+###############################################################################
+
 add_library(
   wasmdemo_lib
   OBJECT
@@ -38,6 +42,10 @@ else()
   )
 endif()
 
+###############################################################################
+# wasmdemo browser binary
+###############################################################################
+
 if(WASMDEMO_TARGET_WASM32)
   add_executable(wasmdemo src/wasmdemo_main.cc)
   set_property(TARGET wasmdemo PROPERTY OUTPUT_NAME wasmdemo.wasm)
@@ -54,21 +62,32 @@ if(WASMDEMO_TARGET_WASM32)
   )
 endif()
 
-add_executable(
-  wasmdemo_test
-  test/wasmdemo_imports_impl.cc
-  test/wasmdemo_test.cc
-)
+###############################################################################
+# wasmdemo_lib unit tests
+###############################################################################
 
-target_include_directories(
-  wasmdemo_test
-  PUBLIC
-  "${CMAKE_CURRENT_LIST_DIR}/test"
-)
+if(BUILD_TESTING)
+  add_executable(
+    wasmdemo_test
+    test/wasmdemo_imports_impl.cc
+    test/wasmdemo_test.cc
+  )
 
-target_link_libraries(
-  wasmdemo_test
-  PRIVATE
-  wasmdemo_lib
-  gmock_main
-)
+  target_include_directories(
+    wasmdemo_test
+    PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/test"
+  )
+
+  target_link_libraries(
+    wasmdemo_test
+    PRIVATE
+    wasmdemo_lib
+    gmock_main
+  )
+
+  add_test(
+    NAME wasmdemo_ctest
+    COMMAND wasmdemo_test
+  )
+endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,7 +87,7 @@ if(BUILD_TESTING)
   )
 
   add_test(
-    NAME wasmdemo_ctest
+    NAME wasmdemo_test
     COMMAND wasmdemo_test
   )
 endif()

--- a/cpp/src/wasmdemo_main.cc
+++ b/cpp/src/wasmdemo_main.cc
@@ -1,0 +1,1 @@
+// This file is intentionally empty.

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package (
     Interpreter
 )
 
+find_package(
+  Patch
+  REQUIRED
+)
+
 function(
   dep_setup
   ARG_PACKAGE_NAME
@@ -47,6 +52,7 @@ function(
     "${ARG_PACKAGE_VERSION}"
     "${ARG_DOWNLOAD_URL_FIXED}"
     "${ARG_EXPECTED_SHA256}"
+    "--patch_executable=${Patch_EXECUTABLE}"
     "${PACKAGE_DEST_DIR}"
   )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -75,42 +75,52 @@ function(
   add_subdirectory("${PACKAGE_DEST_DIR}")
 endfunction(dep_setup)
 
+if(WASMDEMO_TARGET_WASM32)
+  set(
+    GTEST_HAS_ABSL
+    OFF
+    CACHE
+    BOOL
+    "Tell googletest that absl and re2 are available."
+  )
+else()
+  set(
+    GTEST_HAS_ABSL
+    ON
+    CACHE
+    BOOL
+    "Tell googletest that absl and re2 are available."
+  )
+
+  set(
+    ABSL_PROPAGATE_CXX_STD
+    ON
+    CACHE
+    BOOL
+    "Recommended by abseil since it will be the default in the future."
+  )
+
+  dep_setup(
+    "abseil"
+    "6dab0bd99c5856e747fe35e928395ae80ca5e5f1"
+    "https://github.com/abseil/abseil-cpp/archive/__PACKAGE_VERSION__.zip"
+    "57bffa111dac74fd4b0c7d4652a2a36cf0fd93c35b097b3a131f9414aaedc0b3"
+  )
+
+  dep_setup(
+    "re2"
+    "4be240789d5b322df9f02b7e19c8651f3ccbf205"
+    "https://github.com/google/re2/archive/__PACKAGE_VERSION__.zip"
+    "99ce27e7f11ab52776fd80daa2cae0d4045a021e93a03ed514951ba3d25f3982"
+  )
+endif()
+
 set(
   INSTALL_GTEST
   OFF
   CACHE
   BOOL
   "Disable installation of googletest, since it's only embedded."
-)
-
-set(
-  GTEST_HAS_ABSL
-  ON
-  CACHE
-  BOOL
-  "Tell googletest that absl and re2 are available."
-)
-
-set(
-  ABSL_PROPAGATE_CXX_STD
-  ON
-  CACHE
-  BOOL
-  "Recommended by abseil since it will be the default in the future."
-)
-
-dep_setup(
-  "abseil"
-  "6dab0bd99c5856e747fe35e928395ae80ca5e5f1"
-  "https://github.com/abseil/abseil-cpp/archive/__PACKAGE_VERSION__.zip"
-  "57bffa111dac74fd4b0c7d4652a2a36cf0fd93c35b097b3a131f9414aaedc0b3"
-)
-
-dep_setup(
-  "re2"
-  "4be240789d5b322df9f02b7e19c8651f3ccbf205"
-  "https://github.com/google/re2/archive/__PACKAGE_VERSION__.zip"
-  "99ce27e7f11ab52776fd80daa2cae0d4045a021e93a03ed514951ba3d25f3982"
 )
 
 dep_setup(

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -123,9 +123,11 @@ set(
   "Disable installation of googletest, since it's only embedded."
 )
 
-dep_setup(
-  "googletest"
-  "97459e54ec4f1882d219c413c929f719d9741ada"
-  "https://github.com/google/googletest/archive/__PACKAGE_VERSION__.zip"
-  "af17569ac5c05b148ae336a43ae7ab144d2cc5f3bfd3c9beb952cdd9a9fb0f75"
-)
+if(BUILD_TESTING)
+  dep_setup(
+    "googletest"
+    "97459e54ec4f1882d219c413c929f719d9741ada"
+    "https://github.com/google/googletest/archive/__PACKAGE_VERSION__.zip"
+    "af17569ac5c05b148ae336a43ae7ab144d2cc5f3bfd3c9beb952cdd9a9fb0f75"
+  )
+endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,6 +18,14 @@ function(
   ARG_DOWNLOAD_URL
   ARG_EXPECTED_SHA256
 )
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    "ARG" # <prefix>
+    "" # <options>
+    "" # <one_value_keywords>
+    "PATCHES" # <multi_value_keywords>
+  )
+
   if("${ARG_PACKAGE_NAME}" STREQUAL "")
     message(FATAL_ERROR "ARG_PACKAGE_NAME must be specified to ${CMAKE_CURRENT_FUNCTION}")
   endif()
@@ -52,9 +60,18 @@ function(
     "${ARG_PACKAGE_VERSION}"
     "${ARG_DOWNLOAD_URL_FIXED}"
     "${ARG_EXPECTED_SHA256}"
-    "--patch_executable=${Patch_EXECUTABLE}"
     "${PACKAGE_DEST_DIR}"
+    "--patch_executable=${Patch_EXECUTABLE}"
   )
+
+  foreach(patch_file ${ARG_PATCHES})
+    list(
+      APPEND
+      DEP_SETUP_PY_ARGS
+      "--patch"
+      "${patch_file}"
+    )
+  endforeach()
 
   string(JOIN " " DEP_SETUP_PY_ARGS_STR ${DEP_SETUP_PY_ARGS})
   message(
@@ -130,10 +147,21 @@ set(
 )
 
 if(BUILD_TESTING)
+  if(WASMDEMO_TARGET_WASM32)
+    set(
+      googletest_dep_setup_extra_args
+      "PATCHES"
+      "${CMAKE_CURRENT_LIST_DIR}/googletest.noexceptions.patch.txt"
+    )
+  else()
+    set(googletest_dep_setup_extra_args "")
+  endif()
+
   dep_setup(
     "googletest"
     "97459e54ec4f1882d219c413c929f719d9741ada"
     "https://github.com/google/googletest/archive/__PACKAGE_VERSION__.zip"
     "af17569ac5c05b148ae336a43ae7ab144d2cc5f3bfd3c9beb952cdd9a9fb0f75"
+    ${googletest_dep_setup_extra_args}
   )
 endif()

--- a/external/googletest.noexceptions.patch.txt
+++ b/external/googletest.noexceptions.patch.txt
@@ -1,0 +1,18 @@
+diff -Naur googletest/googletest/cmake/internal_utils.cmake googletest_noexceptions/googletest/cmake/internal_utils.cmake
+--- googletest/googletest/cmake/internal_utils.cmake	2022-12-13 11:48:35.468421162 -0500
++++ googletest_noexceptions/googletest/cmake/internal_utils.cmake	2022-12-13 11:49:50.023517078 -0500
+@@ -141,7 +141,13 @@
+   set(cxx_base_flags "${cxx_base_flags} ${GTEST_HAS_PTHREAD_MACRO}")
+ 
+   # For building gtest's own tests and samples.
+-  set(cxx_exception "${cxx_base_flags} ${cxx_exception_flags}")
++
++  # Specify the "no exceptions" flag even for `cxx_exception`
++  # because the wasm32-wasi targets do not support exceptions
++  # and specifying -fexceptions leads to linker errors like
++  # "undefined symbol: __cxa_allocate_exception" and
++  # "undefined symbol: __cxa_throw".
++  set(cxx_exception "${cxx_base_flags} ${cxx_no_exception_flags}")
+   set(cxx_no_exception
+     "${CMAKE_CXX_FLAGS} ${cxx_base_flags} ${cxx_no_exception_flags}")
+   set(cxx_default "${cxx_exception}")

--- a/wasm32.toolchain.cmake
+++ b/wasm32.toolchain.cmake
@@ -40,3 +40,11 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_C_FLAGS_INIT "")
 set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions -fno-rtti")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fno-exceptions -fno-rtti")
+
+find_program(
+  WASMDEMO_WASMTIME_EXECUTABLE
+  wasmtime
+  REQUIRED
+  DOC "The wasmtime executable to use to run wasm32 binaries."
+)
+set(CMAKE_CROSSCOMPILING_EMULATOR wasmtime)

--- a/wasm32.toolchain.cmake
+++ b/wasm32.toolchain.cmake
@@ -39,4 +39,4 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_C_FLAGS_INIT "")
 set(CMAKE_CXX_FLAGS_INIT "-fno-exceptions -fno-rtti")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostartfiles -Wl,--no-entry -fno-exceptions -fno-rtti")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fno-exceptions -fno-rtti")


### PR DESCRIPTION
Now, when targeting wasm32 you can build and run the unit tests written in googletest. This is done by using the wasmtime "webassembly runtime": https://wasmtime.dev/. This means that wasmtime is now a hard dependency when targeting webassembly. The README.md has been updated with instructions to install wasmtime.

There are also some other changes in this PR:
1. cmake's ctest support was added; you can now run `ctest` in the "build" directory to run the tests.
2. googletest is patched to never specify `-fexceptions`, since wasm32-wasi does not support it.